### PR TITLE
Add support for counting HCL (Terraform) files

### DIFF
--- a/codebase_token_counter/token_counter.py
+++ b/codebase_token_counter/token_counter.py
@@ -123,6 +123,7 @@ FILE_EXTENSIONS = {
     '.hrl': 'Erlang Header',
     '.hs': 'Haskell',
     '.lhs': 'Literate Haskell',
+    '.hcl': 'HCL (Terraform)',
     '.lua': 'Lua',
     '.r': 'R',
     '.rmd': 'R Markdown',


### PR DESCRIPTION
Hashicorp Configuration Language (HCL) is used by Terraform / OpenTofu and is one of the [fastest-growing languages](https://github.blog/news-insights/octoverse/octoverse-2024/) on GitHub. This PR adds support for counting tokens in files containing HCL.